### PR TITLE
比較ができなくなっている問題の対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=ecae181de592",
     "storycap": "storycap -C puppeteer --serverCmd 'start-storybook -p 6006' http://localhost:6006 --serverTimeout 60000",
-    "regression": "export EXPECTED_HASH=$(git rev-parse --short origin/develop) && export ACTUAL_BRANCH=$(git rev-parse --short --abbrev-ref @) && export ACTUAL_BRANCH_HASH=$(git rev-parse --short HEAD) && export ACTUAL_COMMIT_DATE=$(git log --date=iso --date=format:'%Y_%m_%d' --pretty=format:'%ad' -1) && reg-suit run"
+    "regression": "export EXPECTED_HASH=$(git rev-parse --short origin/develop) && export EXPECTED_COMMIT_DATE=$(git log origin/develop --date=iso --date=format:'%Y_%m_%d' --pretty=format:'%ad' -1) && export ACTUAL_BRANCH=$(git rev-parse --short --abbrev-ref @) && export ACTUAL_BRANCH_HASH=$(git rev-parse --short HEAD) && export ACTUAL_COMMIT_DATE=$(git log --date=iso --date=format:'%Y_%m_%d' --pretty=format:'%ad' -1) && reg-suit run"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.9",

--- a/regconfig.json
+++ b/regconfig.json
@@ -19,7 +19,7 @@
       "pathPrefix": "resource"
     },
     "reg-simple-keygen-plugin": {
-      "expectedKey": "develop_${EXPECTED_HASH}_2022_05_15",
+      "expectedKey": "develop_${EXPECTED_HASH}_${EXPECTED_COMMIT_DATE}",
       "actualKey": "${ACTUAL_BRANCH}_${ACTUAL_BRANCH_HASH}_${ACTUAL_COMMIT_DATE}"
     }
   }

--- a/regconfig.json
+++ b/regconfig.json
@@ -19,7 +19,7 @@
       "pathPrefix": "resource"
     },
     "reg-simple-keygen-plugin": {
-      "expectedKey": "expected_develop_${EXPECTED_HASH}",
+      "expectedKey": "${EXPECTED_HASH}",
       "actualKey": "${ACTUAL_BRANCH}_${ACTUAL_BRANCH_HASH}_${ACTUAL_COMMIT_DATE}"
     }
   }

--- a/regconfig.json
+++ b/regconfig.json
@@ -19,7 +19,7 @@
       "pathPrefix": "resource"
     },
     "reg-simple-keygen-plugin": {
-      "expectedKey": "${EXPECTED_HASH}",
+      "expectedKey": "develop_${EXPECTED_HASH}_2022_05_15",
       "actualKey": "${ACTUAL_BRANCH}_${ACTUAL_BRANCH_HASH}_${ACTUAL_COMMIT_DATE}"
     }
   }

--- a/src/components/atoms/Button/styles.ts
+++ b/src/components/atoms/Button/styles.ts
@@ -12,5 +12,4 @@ export const Button = styled.a`
   text-decoration: none;
   text-transform: uppercase;
   cursor: pointer;
-  border: 1px solid #ff0000;
 `;


### PR DESCRIPTION
expectedキーが作成したdevelopのキーと一致している必要がある。
対応としては、developの最新コミットのハッシュ値と日付を取得してキー名を取得することにした。